### PR TITLE
Required dependency curated feed lets in too many packages

### DIFF
--- a/src/NuGetGallery/PackageCurators/RequiredDependencyPackageCurator.cs
+++ b/src/NuGetGallery/PackageCurators/RequiredDependencyPackageCurator.cs
@@ -74,7 +74,9 @@ namespace NuGetGallery
         IsMinInclusive = true,
         MinVersion =
           new SemanticVersion(dependencyVersionSpec.MinVersion.Version.Major,
-            dependencyVersionSpec.MinVersion.Version.Minor, 0, 0)
+            dependencyVersionSpec.MinVersion.Version.Minor, 0, 0),
+        IsMaxInclusive = dependencyVersionSpec.IsMaxInclusive,
+        MaxVersion = dependencyVersionSpec.MaxVersion
       };
 
       return spec;

--- a/tests/NuGetGallery.Facts/PackageCurators/RequiredDependencyPackageCuratorFacts.cs
+++ b/tests/NuGetGallery.Facts/PackageCurators/RequiredDependencyPackageCuratorFacts.cs
@@ -195,6 +195,8 @@ namespace NuGetGallery.PackageCurators
             [Theory]
             [InlineData(TestableRequiredDependencyPackageCurator.RequiredDependencyPackageId, "3.1")]
             [InlineData(TestableRequiredDependencyPackageCurator.RequiredDependencyPackageId, "4.0")]
+            [InlineData(TestableRequiredDependencyPackageCurator.RequiredDependencyPackageId, "[2.0,2.9]")]
+            [InlineData(TestableRequiredDependencyPackageCurator.RequiredDependencyPackageId, "[2.0,3.0)")]
             public void WillNotIncludeThePackageWhenTheDependencyVersionSpecDoesNotMatch(string dependentPackageId, string versionSpec)
             {
                 var curator = new TestableRequiredDependencyPackageCurator();


### PR DESCRIPTION
The logic to ignore patch version didn't maintain the max version, so it would let in packages it shouldn't have, e.g. if I had [8.0,8.2), then ReSharper_v8.2 would accept the package.
