### PR TITLE
Don't return excluded curated packages

### DIFF
--- a/src/NuGetGallery/Services/CuratedFeedService.cs
+++ b/src/NuGetGallery/Services/CuratedFeedService.cs
@@ -146,7 +146,7 @@ namespace NuGetGallery
         {
             var packages = CuratedFeedRepository.GetAll()
                 .Where(cf => cf.Name == curatedFeedName)
-                .SelectMany(cf => cf.Packages.SelectMany(cp => cp.PackageRegistration.Packages));
+                .SelectMany(cf => cf.Packages.Where(cp => cp.Included).SelectMany(cp => cp.PackageRegistration.Packages));
 
             return packages;
         }
@@ -155,7 +155,7 @@ namespace NuGetGallery
         {
             var packageRegistrations = CuratedFeedRepository.GetAll()
                 .Where(cf => cf.Name == curatedFeedName)
-                .SelectMany(cf => cf.Packages.Select(cp => cp.PackageRegistration));
+                .SelectMany(cf => cf.Packages.Where(cp => cp.Included).Select(cp => cp.PackageRegistration));
 
             return packageRegistrations;
         }


### PR DESCRIPTION
The API for curated feeds returns all `Package`s, even if the `CuratedPackage` has been excluded. This filters on the `Include` property to only return packages that are included in the feed.